### PR TITLE
Add Helm plugin for Chkk

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright © 2021 Chkk <support@chkk.io>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
-# helm-chkk
-Check Kubernetes manifests in your charts for reliability risks
+# Check your Helm Chart for Reliability Risks
+
+A Helm plugin for using Chkk to catch reliability risks in your Helm charts.
+
+## Installation
+
+Install the Chkk plugin using the built in `helm plugin install` command provided by the Helm plugin manager.
+
+```bash
+$ cd <path_to_helm-chkk_directory>/helm-chkk
+$ helm plugin install .
+```
+
+The plugin connects to the Chkk service to lookup reliability risks information. If you don't already have your personal access token, go to [https://www.chkk.dev](https://www.chkk.dev) to sign up for free and get the access token.
+
+You should set the `CHKK_ACCESS_TOKEN` environment variable as shown below:
+
+```bash
+export CHKK_ACCESS_TOKEN=<your-chkk-access-token>
+```
+
+## Usage
+
+Run `helm chkk` command and point it to the Helm chart you want to run checks on. For example:
+
+```console
+$ helm chkk coredns coredns/coredns
+[FAILED] [CHKK-K8S-36] [High Severity] Image pull policy should not be set to Always
+   Impact: imagePullPolicy=Always means you're exercising your dependencies on every container launch.
+   If there's network disruption or the registry is down, your application launch will fail.
+
+   Recommendations:
+      (1) Set ImagePullPolicy to IfNotPresent for each container.
+
+   Knowledge base:  https://docs.chkk.dev/docs/chkk-k8s-36
+...
+
+Target manifest:  coredns.yaml
+Found  5 issues with High severity
+Found  1 issues with Medium severity
+Found  3 issues with Low severity
+Summary:
+	Total Passed: 11
+	Total Failed: 9
+	Total Skipped: 0
+...
+```
+
+The Chkk plugin supports various arguments for modifying the chart, including `--set` and `--values`. For example, you can run checks on a chart while overriding the image as following:
+
+```bash
+helm chkk coredns coredns/coredns --set image.tag=1.8.3
+```
+
+Chkk has properties that allow a user to run or skip specific checks. These options are automatically passed to Chkk, with any other options being passed to Helm in the same manner as `helm template`.
+
+| Flag | Default | Description |
+| :---: |:---: | :---: |
+| --file, -f | | The name of the Kubernetes manifest file you want to test.|
+| --skip-checks, -s | | Skip specified list of comma separated checks in the run.|
+| --run-checks, -r | | Run specified list of comma separated checks in the run.|
+| --hide-diff         | false   | Hide code-diff in result output               |
+| --continue-on-error | false | Do not raise error in case a check fails |
+
+
+For further options and features, please refer to the help instructions with the `helm chkk --help` flag.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,10 @@
+name: "chkk"
+version: "0.0.1"
+usage: "Check helm charts for reliability risks"
+description: "Chkk Helm plugin scans your Helm charts for reliability risks."
+ignoreFlags: false
+command: "$HELM_PLUGIN_DIR/scripts/run.sh"
+
+hooks:
+  install: "$HELM_PLUGIN_DIR/scripts/install.sh"
+  update: "$HELM_PLUGIN_DIR/scripts/install.sh"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,90 @@
+#! /bin/bash -e
+
+# Install helm-chkk as Helm plugin by downloading the Chkk CLI package and copying it to
+# helm/plugins folder
+
+set -e
+PROJECT_NAME="helm-chkk"
+HELM_CHKK_VERSION="$(cat plugin.yaml | grep "version" | cut -d '"' -f 2)"
+echo "Installing helm-chkk v${HELM_CHKK_VERSION} ..."
+
+# Set $HELM_PLUGIN_DIR as the current working directory
+cd $HELM_PLUGIN_DIR
+
+
+# init_arch discovers the architecture for the target system.
+init_arch() {
+  ARCH=$(uname -m)
+  case $ARCH in
+    x86_64) ARCH="amd64";;
+    *) ARCH="unknown";;
+  esac
+}
+
+# init_os discovers the operating system for the target system.
+init_os() {
+  OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+}
+
+# verify_supported checks that the os/arch combination is supported for
+# Chkk binary packages. Currently supported platforms are:
+# (1) linux-amd64
+# (2) darwin-amd64
+verify_supported() {
+  local __supported="linux-amd64\darwin-amd64"
+  if ! echo "${__supported}" | grep -q "${OS}-${ARCH}"; then
+    echo "No prebuild Chkk binary is supported for target system: ${OS}-${ARCH}."
+    exit 1
+  fi
+
+  if ! type "curl" >/dev/null 2>&1; then
+    echo "curl is required"
+    exit 1
+  fi
+}
+
+# download_package downloads the Chkk CLI package from remote
+# repository.
+download_package() {
+  local __cli_version="0.0.1"
+  local __download_url="https://downloads.chkk.dev/v${__cli_version}/chkk-${OS}-${ARCH}"
+  echo "Downloading helm-chkk package" 
+  curl -sSLo chkk $__download_url
+  chmod +x chkk
+}
+
+# install_plugin installs the helm-chkk plugin by copying the binary
+# to $HELM_PLUGIN_DIR
+install_plugin() {
+  echo "Preparing to install into ${HELM_PLUGIN_DIR}"
+  rm -rf bin && mkdir bin
+  mv chkk bin/
+  echo "$PROJECT_NAME installed into ${HELM_PLUGIN_DIR}"
+}
+
+# fail_trap is executed if an error occurs during installation.
+fail_trap() {
+  local __result=$?
+  if [ "$r__result" != "0" ]; then
+    echo "Failed to install $PROJECT_NAME"
+    echo "For support, go to https://github.com/kubernetes/helm"
+  fi
+  exit $__result
+}
+
+# test_version verifies the installed plugin is working correctly
+# by displaying the help() message.
+test_version() {
+  PATH=$PATH:$HELM_PLUGIN_PATH
+  helm chkk -h
+}
+
+# Stop script execution on any error
+trap "fail_trap" EXIT
+
+init_arch
+init_os
+verify_supported
+download_package
+install_plugin
+test_version

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,45 @@
+#! /bin/bash -e
+
+HELM_BIN="${HELM_BIN:-helm}"
+HELM_CHKK_VERSION="$(cat ${HELM_PLUGIN_DIR}/plugin.yaml | grep "version" | cut -d '"' -f 2)"
+
+helm_options=()
+chkk_options=()
+eoo=0
+
+while [[ $1 ]]
+do
+    if ! ((eoo)); then
+        case "$1" in
+            --version|-v|version)
+                echo "Helm Chkk Version: $HELM_CHKK_VERSION"
+                exit
+                ;;
+            --help|-h|--list|config)
+                $HELM_PLUGIN_DIR/bin/chkk $1
+                exit
+                ;;
+            --continue-on-error|--hide-diff)
+                chkk_options+=("$1")
+                shift
+                ;;
+            --run-checks|-r|--skip-checks|-s)
+                chkk_options+=("$1")
+                chkk_options+=("$2")
+                shift 2
+                ;;
+            *)
+                helm_options+=("$1")
+                shift
+                ;;
+        esac
+    else
+        helm_options+=("$1")
+        shift
+    fi
+done
+
+echo "Rendering template for ${helm_options[0]} ..."
+render=$(${HELM_BIN} template "${helm_options[@]}")
+
+$HELM_PLUGIN_DIR/bin/chkk -- -f "$render" --name "${helm_options[0]}" "${chkk_options[@]}"


### PR DESCRIPTION
## Description
* Added Helm plugin for Chkk
* Run `helm chkk` command and point it to the Helm chart you want to run checks on.


## Installation

Install the Chkk plugin using the built in `helm plugin install` command provided by the Helm plugin manager.

```bash
$ cd <path_to_helm-chkk_directory>/helm-chkk
$ helm plugin install .
```

The plugin connects to the Chkk service to lookup reliability risks information. If you don't already have your personal access token, go to [https://www.chkk.dev](https://www.chkk.dev) to sign up for free and get the access token.

You should set the `CHKK_ACCESS_TOKEN` environment variable as shown below:

```bash
export CHKK_ACCESS_TOKEN=<your-chkk-access-token>
```
