### PR TITLE
Renamed helm-chkk plugin binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Chkk has properties that allow a user to run or skip specific checks. These opti
 
 | Flag | Default | Description |
 | :---: |:---: | :---: |
-| --file, -f | | The name of the Kubernetes manifest file you want to test.|
 | --skip-checks, -s | | Skip specified list of comma separated checks in the run.|
 | --run-checks, -r | | Run specified list of comma separated checks in the run.|
 | --show-diff         | false   | Show code-diff in result output               |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -50,8 +50,8 @@ download_package() {
   local __cli_version="0.0.1"
   local __download_url="https://downloads.chkk.dev/v${__cli_version}/chkk-${OS}-${ARCH}"
   echo "Downloading helm-chkk package" 
-  curl -sSLo chkk $__download_url
-  chmod +x chkk
+  curl -sSLo helm-chkk $__download_url
+  chmod +x helm-chkk
 }
 
 # install_plugin installs the helm-chkk plugin by copying the binary
@@ -59,7 +59,7 @@ download_package() {
 install_plugin() {
   echo "Preparing to install into ${HELM_PLUGIN_DIR}"
   rm -rf bin && mkdir bin
-  mv chkk bin/
+  mv helm-chkk bin/
   echo "$PROJECT_NAME installed into ${HELM_PLUGIN_DIR}"
 }
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -39,6 +39,12 @@ do
     fi
 done
 
+if [ -z "${helm_options[0]}" ]
+then
+    $HELM_PLUGIN_DIR/bin/helm-chkk -h
+    exit
+fi
+
 echo "Rendering template for ${helm_options[0]} ..."
 render=$(${HELM_BIN} template "${helm_options[@]}")
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -16,7 +16,7 @@ do
                 exit
                 ;;
             --help|-h|--list|config)
-                $HELM_PLUGIN_DIR/bin/chkk $1
+                $HELM_PLUGIN_DIR/bin/helm-chkk $1
                 exit
                 ;;
             --continue-on-error|--show-diff)
@@ -42,4 +42,4 @@ done
 echo "Rendering template for ${helm_options[0]} ..."
 render=$(${HELM_BIN} template "${helm_options[@]}")
 
-$HELM_PLUGIN_DIR/bin/chkk -- -f "$render" --name "${helm_options[0]}" "${chkk_options[@]}"
+$HELM_PLUGIN_DIR/bin/helm-chkk -- -f "$render" --name "${helm_options[0]}" "${chkk_options[@]}"


### PR DESCRIPTION
## Description

* Renamed helm-chkk plugin binary from `chkk` to `helm-chkk`
* Remove redundant `file` flag from README description